### PR TITLE
add plugin "shadow" to Gradle so that JAR with Kotlin-Runtime can be created easily

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.6.20"
+    id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 group = "org.sipura"


### PR DESCRIPTION
Use `./gradlew shadowJar` or the integration in IntelliJ to use it:
![image](https://user-images.githubusercontent.com/25711926/206864847-70b41980-0679-4189-85e4-b3f1b2ee1a60.png)
